### PR TITLE
Extract and reuse Frontmatter parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,28 @@ In `app/views/layouts/pages.html.erb`:
 <% end %>
 ```
 
+Frontmatter is supplied as a struct like object.
+
+Given this frontmatter:
+
+```yaml
+---
+author: Beelzebub
+---
+```
+
+Use `!` and `?` method helpers for added strictness.
+
+```ruby
+data.author  # => "Beelzebub"
+data.author! # => "Beelzebub"
+data.author? # => true
+
+data.title   # => nil
+data.title!  # => raises SatanicPages::Frontmatter::MissingAttributeError
+data.title?  # => false
+```
+
 ## Installation
 Add this line to your application's Gemfile:
 

--- a/lib/satanic_pages.rb
+++ b/lib/satanic_pages.rb
@@ -1,13 +1,15 @@
+# frozen_string_literal: true
+
 require "markdown-rails"
 
 require "satanic_pages/version"
 require "satanic_pages/railtie"
 
+require "satanic_pages/controller"
+require "satanic_pages/frontmatter"
+require "satanic_pages/layout_helper"
 require "satanic_pages/page"
 require "satanic_pages/page_list"
-
-require "satanic_pages/controller"
-require "satanic_pages/layout_helper"
 
 module SatanicPages
 end

--- a/lib/satanic_pages/controller.rb
+++ b/lib/satanic_pages/controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SatanicPages
   module Controller
     extend ActiveSupport::Concern

--- a/lib/satanic_pages/frontmatter.rb
+++ b/lib/satanic_pages/frontmatter.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+require "ostruct"
+
+module SatanicPages
+  class Frontmatter
+    def initialize(source)
+      @source = source
+      @data = nil
+      @rest = nil
+      parse!
+    end
+
+    attr_reader :source, :data, :rest
+
+    private
+
+    def parse!
+      frontmatter = nil
+
+      @rest = source.gsub(/\A---\n(.*?)\n---\n/m) do
+        begin
+          frontmatter = YAML.safe_load($1)
+          ""
+        rescue => e
+          Rails.logger.error("Error parsing frontmatter: #{e.message}")
+          $&
+        end
+      end
+
+      @data = OpenStruct.new(frontmatter)
+    end
+  end
+end

--- a/lib/satanic_pages/layout_helper.rb
+++ b/lib/satanic_pages/layout_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SatanicPages
   module LayoutHelper
     # Thank you Sitepress for this lil' goodie

--- a/lib/satanic_pages/markdown_template_handler.rb
+++ b/lib/satanic_pages/markdown_template_handler.rb
@@ -3,9 +3,9 @@
 module SatanicPages
   class MarkdownTemplateHandler < MarkdownRails::Renderer::Rails
     def preprocess(source)
-      frontmatter = Frontmatter.new(source)
+      frontmatter, rest = Frontmatter.parse(source)
 
-      render(inline: frontmatter.rest, handler: :erb, locals: {data: frontmatter.data})
+      render(inline: rest, handler: :erb, locals: {data: frontmatter})
         # Remove template comments
         .gsub(/<!-- (BEGIN|END) (.*) -->/, "")
         # Force HTML tags to be inline

--- a/lib/satanic_pages/markdown_template_handler.rb
+++ b/lib/satanic_pages/markdown_template_handler.rb
@@ -1,21 +1,11 @@
+# frozen_string_literal: true
+
 module SatanicPages
   class MarkdownTemplateHandler < MarkdownRails::Renderer::Rails
     def preprocess(source)
-      frontmatter = {}
+      frontmatter = Frontmatter.new(source)
 
-      content = source.gsub(/\A---\n(.*?)\n---\n/m) do
-        begin
-          frontmatter = YAML.safe_load($1)
-          ""
-        rescue => e
-          Rails.logger.error("Error parsing frontmatter: #{e.message}")
-          $&
-        end
-      end
-
-      data = OpenStruct.new(frontmatter)
-
-      render(inline: content, handler: :erb, locals: {data:})
+      render(inline: frontmatter.rest, handler: :erb, locals: {data: frontmatter.data})
         # Remove template comments
         .gsub(/<!-- (BEGIN|END) (.*) -->/, "")
         # Force HTML tags to be inline

--- a/lib/satanic_pages/page.rb
+++ b/lib/satanic_pages/page.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require "ostruct"
-
 module SatanicPages
   class Page
     def initialize(full_path, base_path)
@@ -28,17 +26,9 @@ module SatanicPages
 
       @raw = File.read(full_path)
 
-      @content = @raw.gsub(/\A---\n(.*?)\n---\n/m) do
-        begin
-          @data = OpenStruct.new(YAML.safe_load($1))
-          nil
-        rescue => e
-          Rails.logger.error("Error parsing frontmatter: #{e.message}")
-          $&
-        end
-      end
-
-      @data ||= OpenStruct.new
+      fm = Frontmatter.new(@raw)
+      @content = fm.rest
+      @data = fm.data
     end
   end
 end

--- a/lib/satanic_pages/page.rb
+++ b/lib/satanic_pages/page.rb
@@ -26,9 +26,7 @@ module SatanicPages
 
       @raw = File.read(full_path)
 
-      fm = Frontmatter.new(@raw)
-      @content = fm.rest
-      @data = fm.data
+      @data, @content = Frontmatter.parse(@raw)
     end
   end
 end

--- a/lib/satanic_pages/railtie.rb
+++ b/lib/satanic_pages/railtie.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SatanicPages
   class Railtie < ::Rails::Railtie
     initializer("satanic_pages.view_helpers") do

--- a/lib/satanic_pages/version.rb
+++ b/lib/satanic_pages/version.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module SatanicPages
   VERSION = "0.2.0"
 end

--- a/test/lib/satanic_pages/page_test.rb
+++ b/test/lib/satanic_pages/page_test.rb
@@ -44,7 +44,7 @@ module SatanicPages
         assert_equal "test_page", page.slug
         assert_equal "test_page", page.path
         assert_match "# Just content", page.content
-        assert page.data.is_a?(OpenStruct), "Should initialize data as OpenStruct"
+        assert page.data.is_a?(Frontmatter), "Should initialize data as Frontmatter"
         assert_nil page.data.title
       end
     end
@@ -74,7 +74,7 @@ module SatanicPages
         page = Page.new(temp_file, @tmp_path)
 
         assert_equal "invalid_frontmatter", page.slug
-        assert page.data.is_a?(OpenStruct), "Should initialize data as OpenStruct even with invalid YAML"
+        assert page.data.is_a?(Frontmatter), "Should initialize data as Frontmatter even with invalid YAML"
         # The entire frontmatter block should be included in content since parsing failed
         assert_match "---\ntitle: 'Invalid: YAML'\n  broken: indentation\n---", page.content
       end

--- a/test/satanic_pages/frontmatter_test.rb
+++ b/test/satanic_pages/frontmatter_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class SatanicPages::FrontmatterTest < ActiveSupport::TestCase
+  test("it initializes with a hash of attributes") do
+    frontmatter = SatanicPages::Frontmatter.new({title: "My Title"})
+    assert_equal "My Title", frontmatter.title
+  end
+
+  test("freezes source hash") do
+    frontmatter = SatanicPages::Frontmatter.new({title: "My Title"})
+    assert frontmatter.to_h.frozen?
+  end
+
+  test("missing attributes return nil") do
+    frontmatter = SatanicPages::Frontmatter.new({})
+    assert_nil frontmatter.title
+  end
+
+  test("missing attributes with a bang raise an error") do
+    frontmatter = SatanicPages::Frontmatter.new({})
+    assert_raises(SatanicPages::Frontmatter::MissingAttributeError) { frontmatter.title! }
+  end
+
+  test("attributes with a question mark return true if the attribute is present") do
+    frontmatter = SatanicPages::Frontmatter.new({title: "My Title"})
+    assert frontmatter.title?
+    refute frontmatter.author?
+  end
+
+  test("parse: it should parse frontmatter") do
+    frontmatter, rest = SatanicPages::Frontmatter.parse("---\ntitle: My Title\n---\nHello, world!")
+
+    assert_instance_of SatanicPages::Frontmatter, frontmatter
+    assert_equal "My Title", frontmatter.title
+    assert_equal "Hello, world!", rest
+  end
+
+  test("parse: it is empty if the frontmatter is unparseable and rest is original content") do
+    source = "---\ntitle: My Title\n  hi: there---\nHello, world!"
+    frontmatter, rest = SatanicPages::Frontmatter.parse(source)
+
+    assert_instance_of SatanicPages::Frontmatter, frontmatter
+    assert_equal({}, frontmatter.to_h)
+    assert_equal source, rest
+  end
+end


### PR DESCRIPTION
Instead of an OpenStruct, we introduce our own `Frontmatter` object.

It
1. initializes with a hash
2. returns nil for missing attributes
3. adds `attribute!` helper that raises on missing attributes
4. adds `attribute?` helper that returns `true|false` of whether attribute is set